### PR TITLE
set up build services to build the base image

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -1,0 +1,10 @@
+check:
+  - thoth-build
+build:
+  build-stratergy: Dockerfile
+  dockerfile-path: Dockerfile
+  registry: quay.io
+  registry-org: modh
+  registry-project: s2i-python-anaconda-base
+  registry-secret: modh-pusher-secret
+  custom-tag: latest


### PR DESCRIPTION
set up build services to build the base image
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>


This would build the base image using the aicoe-ci bot. 